### PR TITLE
Improve handling output from rsync_transfer

### DIFF
--- a/multi_transfer.py
+++ b/multi_transfer.py
@@ -29,7 +29,7 @@ class MultiRsyncProcess(object):
     def __init__(self, src_path: str, dest_path: str):
         self.src_path = src_path
         self.dest_path = dest_path
-        self.stdout_buffer = tempfile.TemporaryFile(mode="r+")
+        self.stdout_buffer = tempfile.TemporaryFile(mode="r+", buffering=1)
         self.process = multiprocessing.Process(name=src_path,
                                                target=redirect_output(rsync_transfer,
                                                                       self.stdout_buffer),

--- a/transfer.py
+++ b/transfer.py
@@ -1,6 +1,5 @@
 from typing import List
 import subprocess
-import sys
 import os
 
 
@@ -27,17 +26,15 @@ def rsync_transfer(source_path: str, destination_path: str) -> int:
             _get_transfer_command(source_path, destination_path),
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            universal_newlines=True,
-            bufsize=1
+            universal_newlines=True
     ) as process):
         for line in process.stdout:
-            print(line.strip(), end='\r', flush=True)
+            print(line.strip(), end='\r')
 
         for line in process.stderr:
             print(line.strip())
 
     if process.returncode == 0:
         print("\nTransfer completed successfully!")
-    sys.stdout.flush()
 
     return process.returncode


### PR DESCRIPTION
## **Changes:**
* Change stdout_buffer's buffer to minimum size.
* Remove flush fo stdout from rsync_transfer.